### PR TITLE
Add no browse flag

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ function mount(path, callback) {
   var command = [
     'hdiutil',
     'mount',
+    '-nobrowse',
     '"' + path + '"'
   ];
 


### PR DESCRIPTION
This prevents packages from opening the finder window when running background scripts.
